### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/src/Citezen-Reborn.package/CZBblGenerator.class/instance/doiHrefForField..st
+++ b/src/Citezen-Reborn.package/CZBblGenerator.class/instance/doiHrefForField..st
@@ -1,6 +1,6 @@
 utils
 doiHrefForField: aDoiField
-	"Return the \href {http://dx.doi.org/10.1016/j.scico.2014.07.011}
+	"Return the \href {https://doi.org/10.1016/j.scico.2014.07.011}
   {\path{[doi:10.1016/j.scico.2014.07.011] }}, "
-	^ '\href{http://dx.doi.org/', aDoiField value, '}{\path{[doi:', aDoiField value,']}}'
+	^ '\href{https://doi.org/', aDoiField value, '}{\path{[doi:', aDoiField value,']}}'
  

--- a/src/Citezen-Reborn.package/CZDocBuilderTest.class/class/Abde10a.st
+++ b/src/Citezen-Reborn.package/CZDocBuilderTest.class/class/Abde10a.st
@@ -25,7 +25,7 @@ Abde10a
 	X-Proceedings = {yes},
 	Year = 2010,
 	Bdsk-Url-1 = {http://rmod.lille.inria.fr/archives/papers/Abde10a-IST-Official-packageFingerprints.pdf},
-	Bdsk-Url-2 = {http://dx.doi.org/10.1016/j.infsof.2010.07.005}}
+	Bdsk-Url-2 = {https://doi.org/10.1016/j.infsof.2010.07.005}}
 
 '
 )  

--- a/src/Citezen-Reborn.package/CZDocBuilderTest.class/class/someArticles.st
+++ b/src/Citezen-Reborn.package/CZDocBuilderTest.class/class/someArticles.st
@@ -25,7 +25,7 @@ someArticles
 	X-Proceedings = {yes},
 	Year = {2010},
 	Bdsk-Url-1 = {http://rmod.lille.inria.fr/archives/papers/Abde10a-IST-Official-packageFingerprints.pdf},
-	Bdsk-Url-2 = {http://dx.doi.org/10.1016/j.infsof.2010.07.005}}
+	Bdsk-Url-2 = {https://doi.org/10.1016/j.infsof.2010.07.005}}
 
 
 @inproceedings{Denk08b,

--- a/src/Citezen-Reborn.package/CZHTMLGenerator.class/instance/visitField..st
+++ b/src/Citezen-Reborn.package/CZHTMLGenerator.class/instance/visitField..st
@@ -6,7 +6,7 @@ visitField: aField
 	aField isURL
 		ifTrue: [outputStream nextPutAll: '<a href="'].
 	aField isDoi
-		ifTrue: [outputStream nextPutAll: '<a href="http://dx.doi.org/'].	
+		ifTrue: [outputStream nextPutAll: '<a href="https://doi.org/'].	
 	aField dispatchVisitor: self.
 	aField isURL
 		ifTrue: [outputStream nextPutAll: '">PDF</a>'].

--- a/src/Citezen-Reborn.package/CZPillarGenerator.class/instance/visitField..st
+++ b/src/Citezen-Reborn.package/CZPillarGenerator.class/instance/visitField..st
@@ -4,7 +4,7 @@ visitField: aField
 	aField isURL
 		ifTrue: [outputStream nextPutAll: '*PDF>'].
 	aField isDoi
-		ifTrue: [outputStream nextPutAll: '*DOI>http://dx.doi.org/'].	
+		ifTrue: [outputStream nextPutAll: '*DOI>https://doi.org/'].	
 	aField dispatchVisitor: self.
 	aField isURL
 		ifTrue: [outputStream nextPutAll: '*'].


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

Although there is no urgent need to do anything, I'd hereby like to suggest to follow the new recommendation and update all static DOI links, the code that hyperlinks DOIs and the test URLs.

Cheers!