### PR TITLE
Upgrade code examples to Pharo 9+

### DIFF
--- a/src/Citezen-Reborn.package/CZBblGenerator.class/README.md
+++ b/src/Citezen-Reborn.package/CZBblGenerator.class/README.md
@@ -16,7 +16,7 @@ Pay attention, we make sure that DOI and HALID are managed at the end (in case t
 
 
 | visitor bibset |
-bibset := CZBibParser parse: (FileStream readOnlyFileNamed: 'rmod.bib') contents.
+bibset := CZBibParser parse: ('rmod.bib' asFileReference) contents.
 bibset scope: CZSet standardDefinitions.
 visitor := CZBblGenerator new filename: 'rmod.bbl'.
 visitor visit: bibset.

--- a/src/Citezen-Reborn.package/CZBblGenerator.class/properties.json
+++ b/src/Citezen-Reborn.package/CZBblGenerator.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "StephaneDucasse 9/29/2021 18:00",
+	"commentStamp" : "GabinLaigle 12/2/2022 00:27",
 	"super" : "CZFileFormatGenerator",
 	"category" : "Citezen-Reborn-FormattingVisitors",
 	"classinstvars" : [ ],

--- a/src/Citezen-Reborn.package/CZHTMLGenerator.class/README.md
+++ b/src/Citezen-Reborn.package/CZHTMLGenerator.class/README.md
@@ -1,7 +1,7 @@
 A CZHTMLGenerator is generating nice html for us. 
 
 | visitor bibset |
-bibset := CZBibParser parse: (FileStream readOnlyFileNamed: 'rmod.bib') contents.
+bibset := CZBibParser parse: ('rmod.bib' asFileReference) contents.
 bibset scope: CZSet standardDefinitions.
 visitor := CZHTMLGenerator new filename: 'rmod-Generated.html'.
 visitor visit: bibset.

--- a/src/Citezen-Reborn.package/CZHTMLGenerator.class/properties.json
+++ b/src/Citezen-Reborn.package/CZHTMLGenerator.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "StephaneDucasse 8/10/2016 12:45",
+	"commentStamp" : "GabinLaigle 12/2/2022 00:26",
 	"super" : "CZFileFormatGenerator",
 	"category" : "Citezen-Reborn-FormattingVisitors",
 	"classinstvars" : [ ],

--- a/src/Citezen-Reborn.package/CZLaTeXGenerator.class/README.md
+++ b/src/Citezen-Reborn.package/CZLaTeXGenerator.class/README.md
@@ -4,7 +4,7 @@ Currently there is a problem with the generation because it is not simple to see
 
 
 | visitor bibset |
-bibset := CZBibParser parse: (FileStream readOnlyFileNamed: 'rmod.bib') contents.
+bibset := CZBibParser parse: ('rmod.bib' asFileReference) contents.
 bibset scope: CZSet standardDefinitions.
 visitor := CZLaTeXGenerator new filename: 'rmod-Generated.tex'.
 visitor visit: bibset.

--- a/src/Citezen-Reborn.package/CZLaTeXGenerator.class/properties.json
+++ b/src/Citezen-Reborn.package/CZLaTeXGenerator.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "StephaneDucasse 8/10/2016 11:58",
+	"commentStamp" : "GabinLaigle 12/2/2022 00:26",
 	"super" : "CZFileFormatGenerator",
 	"category" : "Citezen-Reborn-FormattingVisitors",
 	"classinstvars" : [ ],


### PR DESCRIPTION
FileStream has been deprecated in Pharo 9.
This pull request replace the FileStream occurrences in generator class comments.