### PR TITLE
Improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ spec
 ## Example script
 
 You can try this simple script to convert a bib file to HTML:
-```Smalltalk
+```
 | bibset visitor |
 bibset := CZBibParser parse: ('/Users/.../input.bib' asFileReference) contents.
 bibset scope: CZSet standardDefinitions.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ $ git clone git@github.com:Ducasse/Citezen.git
 $ cd Citezen
 $ ./scripts/build.sh
 ```
+
 ## Loading for dev
 
 ```
@@ -35,4 +36,15 @@ Metacello new
 spec 
    baseline: 'Citezen' 
    with: [ spec repository: 'github://Ducasse/Citezen' ].
+```
+
+## Example script
+
+You can try this simple script to convert a bib file to HTML:
+```Smalltalk
+| bibset visitor |
+bibset := CZBibParser parse: ('/Users/.../input.bib' asFileReference) contents.
+bibset scope: CZSet standardDefinitions.
+visitor := CZHTMLGenerator new filename: '/Users/.../output.html'.
+visitor visit: bibset.
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ spec
    with: [ spec repository: 'github://Ducasse/Citezen' ].
 ```
 
-## Example script
+## Sample script
 
 You can try this simple script to convert a bib file to HTML:
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ spec
 
 You can try this simple script to convert a bib file to HTML:
 ```
-| bibset visitor |
 bibset := CZBibParser parse: ('/Users/.../input.bib' asFileReference) contents.
 bibset scope: CZSet standardDefinitions.
 visitor := CZHTMLGenerator new filename: '/Users/.../output.html'.


### PR DESCRIPTION
Add a sample script in README.md, to convert a bib file to HTML.
It was kind of hard to find before, as it was only in the class comments.

Also tried to use Smalltalk syntax highlighting, but it was more confusing with it than without.