### PR TITLE
Fix code samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ spec
 
 You can try this simple script to convert a bib file to HTML:
 ```
+| bibset generator |
 bibset := CZBibParser parse: ('/Users/.../input.bib' asFileReference) contents.
 bibset scope: CZSet standardDefinitions.
-visitor := CZHTMLGenerator new filename: '/Users/.../output.html'.
-visitor visit: bibset.
+generator := CZHTMLGenerator new.
+generator save: bibset to: '/Users/.../output.html'.
 ```

--- a/src/Citezen-Reborn.package/CZBblGenerator.class/README.md
+++ b/src/Citezen-Reborn.package/CZBblGenerator.class/README.md
@@ -15,8 +15,8 @@ to generate something like that.....
 Pay attention, we make sure that DOI and HALID are managed at the end (in case they were not specified).
 
 
-| visitor bibset |
+\| bibset generator \|
 bibset := CZBibParser parse: ('rmod.bib' asFileReference) contents.
 bibset scope: CZSet standardDefinitions.
-visitor := CZBblGenerator new filename: 'rmod.bbl'.
-visitor visit: bibset.
+generator := CZBblGenerator new.
+generator save: bibset to: 'rmod-Generated.bbl'.

--- a/src/Citezen-Reborn.package/CZBblGenerator.class/properties.json
+++ b/src/Citezen-Reborn.package/CZBblGenerator.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "GabinLaigle 12/2/2022 00:27",
+	"commentStamp" : "GabinLaigle 12/4/2022 01:10",
 	"super" : "CZFileFormatGenerator",
 	"category" : "Citezen-Reborn-FormattingVisitors",
 	"classinstvars" : [ ],

--- a/src/Citezen-Reborn.package/CZHTMLGenerator.class/README.md
+++ b/src/Citezen-Reborn.package/CZHTMLGenerator.class/README.md
@@ -1,7 +1,7 @@
 A CZHTMLGenerator is generating nice html for us. 
 
-| visitor bibset |
+\| bibset generator \|
 bibset := CZBibParser parse: ('rmod.bib' asFileReference) contents.
 bibset scope: CZSet standardDefinitions.
-visitor := CZHTMLGenerator new filename: 'rmod-Generated.html'.
-visitor visit: bibset.
+generator := CZHTMLGenerator new.
+generator save: bibset to: 'rmod-Generated.html'.

--- a/src/Citezen-Reborn.package/CZHTMLGenerator.class/properties.json
+++ b/src/Citezen-Reborn.package/CZHTMLGenerator.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "GabinLaigle 12/2/2022 00:26",
+	"commentStamp" : "GabinLaigle 12/4/2022 01:10",
 	"super" : "CZFileFormatGenerator",
 	"category" : "Citezen-Reborn-FormattingVisitors",
 	"classinstvars" : [ ],

--- a/src/Citezen-Reborn.package/CZLaTeXGenerator.class/README.md
+++ b/src/Citezen-Reborn.package/CZLaTeXGenerator.class/README.md
@@ -3,8 +3,8 @@ A CZLaTeXGenerator is a generator generating nice latex.
 Currently there is a problem with the generation because it is not simple to see that there is a _ or & in the input text since looking for only one character does not really work (usually we put \& and \_ so more logic should be done.).
 
 
-| visitor bibset |
+\| bibset generator \|
 bibset := CZBibParser parse: ('rmod.bib' asFileReference) contents.
 bibset scope: CZSet standardDefinitions.
-visitor := CZLaTeXGenerator new filename: 'rmod-Generated.tex'.
-visitor visit: bibset.
+generator := CZLaTeXGenerator new.
+generator save: bibset to: 'rmod-Generated.tex'.

--- a/src/Citezen-Reborn.package/CZLaTeXGenerator.class/properties.json
+++ b/src/Citezen-Reborn.package/CZLaTeXGenerator.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "GabinLaigle 12/2/2022 00:26",
+	"commentStamp" : "GabinLaigle 12/4/2022 01:09",
 	"super" : "CZFileFormatGenerator",
 	"category" : "Citezen-Reborn-FormattingVisitors",
 	"classinstvars" : [ ],


### PR DESCRIPTION
Fix [this issue](https://github.com/Ducasse/Citezen/issues/25).

The output stream of generators wasn't closed. As a result, file generations didn't work most of the time.
A better message, closing the stream, already existed but wasn't used in code samples.

Generation worked with some specific bib files as input though, still have no idea why...